### PR TITLE
Remove unneeded pkg-resources

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 click==6.7
 numpy==1.14.1
-pkg-resources==0.0.0
 six==1.11.0
 tensorflow==0.12.0


### PR DESCRIPTION
pip freeze on Ubuntu spuriously adds this:

https://stackoverflow.com/a/40167445/2800111

Follow on to d6413b24879226b9322022ef03aeec767fe43452.